### PR TITLE
feat: add extraVolumeMounts and extraVolumes [CLOUD-3917]

### DIFF
--- a/charts/wiremock/templates/configmap-mappings.yaml
+++ b/charts/wiremock/templates/configmap-mappings.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.mappingsAsConfigmap -}}
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -14,3 +15,4 @@ data:
   {{- with .Values.mappings }}
   {{- toYaml . | nindent 2 }}
   {{- end }}
+{{- end -}}

--- a/charts/wiremock/templates/configmap-responses.yaml
+++ b/charts/wiremock/templates/configmap-responses.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.responsesAsConfigmap -}}
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -14,3 +15,4 @@ data:
   {{- with .Values.responses }}
   {{- toYaml . | nindent 2 }}
   {{- end }}
+{{- end -}}

--- a/charts/wiremock/templates/deployment.yaml
+++ b/charts/wiremock/templates/deployment.yaml
@@ -57,11 +57,19 @@ spec:
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
           volumeMounts:
+            {{- if .Values.mappingsAsConfigmap }}
             - mountPath: /home/wiremock/storage/mappings
               name: mappings-data
+            {{- end }}
+            {{- if .Values.responsesAsConfigmap }}
             - mountPath: /home/wiremock/storage/__files
               name: responses-data
+            {{- end }}
+            {{- with .Values.extraVolumeMounts }}
+              {{- toYaml . | nindent 12 }}
+            {{- end }}
       initContainers:
+        {{- if .Values.mappingsAsConfigmap }}
         - name: copy-mappings
           securityContext:
             {{- toYaml .Values.securityContext | nindent 12 }}
@@ -73,6 +81,8 @@ spec:
               name: mappings-volume
             - mountPath: /home/wiremock/storage/mappings
               name: mappings-data
+        {{- end }}
+        {{- if .Values.responsesAsConfigmap }}
         - name: copy-responses
           securityContext:
             {{- toYaml .Values.securityContext | nindent 12 }}
@@ -84,6 +94,7 @@ spec:
               name: responses-volume
             - mountPath: /home/wiremock/storage/__files
               name: responses-data
+        {{- end }}
         {{- with .Values.extraInitContainers }}
         {{- toYaml . | nindent 8 }}
         {{- end }}
@@ -100,13 +111,20 @@ spec:
         {{- tpl (toYaml .) $ | nindent 8 }}
       {{- end }}
       volumes:
+        {{- if .Values.mappingsAsConfigmap }}
         - name: mappings-data
-          emptyDir: {}
-        - name: responses-data
           emptyDir: {}
         - name: mappings-volume
           configMap:
             name: {{ include "wiremock.fullname" . }}-mappings-configs
+        {{- end }}
+        {{- if .Values.responsesAsConfigmap }}
+        - name: responses-data
+          emptyDir: {}
         - name: responses-volume
           configMap:
             name: {{ include "wiremock.fullname" . }}-responses-configs
+        {{- end }}
+        {{- with .Values.extraVolumes }}
+          {{- toYaml . | nindent 8 }}
+        {{- end }}

--- a/charts/wiremock/values.yaml
+++ b/charts/wiremock/values.yaml
@@ -56,23 +56,23 @@ serviceAccount:
 podAnnotations: {}
 
 podSecurityContext: {}
-  # fsGroupChangePolicy: Always
-  # sysctls: []
-  # supplementalGroups: []
-  # fsGroup: 2000
+#  fsGroupChangePolicy: Always
+#  sysctls: []
+#  supplementalGroups: []
+#  fsGroup: 2000
 
 securityContext: {}
-  # seLinuxOptions: {}
-  # runAsUser: 1000
-  # runAsGroup: 2000
-  # runAsNonRoot: true
-  # privileged: false
-  # readOnlyRootFilesystem: true
-  # allowPrivilegeEscalation: false
-  # capabilities:
-  #   drop: ["ALL"]
-  # seccompProfile:
-  #   type: "RuntimeDefault"
+#  seLinuxOptions: {}
+#  runAsUser: 1000
+#  runAsGroup: 2000
+#  runAsNonRoot: true
+#  privileged: false
+#  readOnlyRootFilesystem: true
+#  allowPrivilegeEscalation: false
+#  capabilities:
+#    drop: ["ALL"]
+#  seccompProfile:
+#    type: "RuntimeDefault"
 
 service:
   type: ClusterIP
@@ -83,8 +83,8 @@ ingress:
   enabled: false
   className: ""
   annotations: {}
-    # kubernetes.io/ingress.class: nginx
-    # kubernetes.io/tls-acme: "true"
+  #  kubernetes.io/ingress.class: nginx
+  #  kubernetes.io/tls-acme: "true"
   hosts:
     - host: chart-example.local
       paths:
@@ -103,17 +103,27 @@ args:
   - "--local-response-templating"
   - "--root-dir=/home/wiremock/storage"
 
+# Disable this if you mount your own mappings using extraVolumeMounts
+mappingsAsConfigmap: true
+
+# Disable this if you mount your own responses using extraVolumeMounts
+responsesAsConfigmap: true
+
+extraVolumeMounts: []
+
+extraVolumes: []
+
 resources: {}
-  # We usually recommend not to specify default resources and to leave this as a conscious
-  # choice for the user. This also increases chances charts run on environments with little
-  # resources, such as Minikube. If you do want to specify resources, uncomment the following
-  # lines, adjust them as necessary, and remove the curly braces after 'resources:'.
-  # limits:
-  #   cpu: 100m
-  #   memory: 128Mi
-  # requests:
-  #   cpu: 100m
-  #   memory: 128Mi
+# We usually recommend not to specify default resources and to leave this as a conscious
+# choice for the user. This also increases chances charts run on environments with little
+# resources, such as Minikube. If you do want to specify resources, uncomment the following
+# lines, adjust them as necessary, and remove the curly braces after 'resources:'.
+#  limits:
+#    cpu: 100m
+#    memory: 128Mi
+#  requests:
+#    cpu: 100m
+#    memory: 128Mi
 
 autoscaling:
   enabled: false


### PR DESCRIPTION
### Context

Forked wiremock/helm-charts to set up this feature while https://github.com/wiremock/helm-charts/pull/60 is waiting for approval & merge

### Solution

The user might want to mount their mappings and responses volumes themselves, in order to get files from other sources such as a PersistentVolume, a S3 bucket, etc. As such, this PR adds `extraVolumeMounts` and `extraVolumes` values, and lets the user disable the default mappings/responses copying from ConfigMap to an emptyDir default behavior. 
